### PR TITLE
Usage of 'bottle: unneeded' has been deprecated

### DIFF
--- a/Formula/dockertags.rb
+++ b/Formula/dockertags.rb
@@ -6,7 +6,6 @@ class Dockertags < Formula
   desc "a CLI tool for fetching container image tags."
   homepage "https://github.com/goodwithtech/dockertags"
   version "0.1.7"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/goodwithtech/dockertags/releases/download/v0.1.7/dockertags_0.1.7_macOS-64bit.tar.gz"

--- a/Formula/dockle.rb
+++ b/Formula/dockle.rb
@@ -6,7 +6,6 @@ class Dockle < Formula
   desc "Simple security auditing, helping build the Best Docker Images"
   homepage "https://github.com/goodwithtech/dockle"
   version "0.4.3"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/sqlboiler.rb
+++ b/Formula/sqlboiler.rb
@@ -6,7 +6,6 @@ class Sqlboiler < Formula
   desc "Generate a Go ORM tailored to your database schema."
   homepage "https://github.com/volatiletech/sqlboiler"
   version "4.4.5"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/goodwithtech/sqlboiler/releases/download/v4.4.5/sqlboiler_4.4.5_macOS-64bit.tar.gz"


### PR DESCRIPTION
Error message
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the goodwithtech/r tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/goodwithtech/homebrew-r/Formula/dockle.rb:9
```

Source: https://github.com/Homebrew/homebrew-core/issues/75943